### PR TITLE
fix: improve syntax and benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ println!("{:?}", toggles);
 ```rust
 use enum_toggles::EnumToggles;
 use log::warn;
-use once_cell::sync::Lazy;
 use std::env;
 use std::ops::Deref;
+use std::sync::LazyLock;
 use strum_macros::{AsRefStr, EnumIter};
 
 #[derive(AsRefStr, EnumIter, PartialEq)]
@@ -62,7 +62,7 @@ enum MyToggle {
     FeatureB,
 }
 
-pub static TOGGLES: Lazy<EnumToggles<MyToggle>> = Lazy::new(|| {
+pub static TOGGLES: LazyLock<EnumToggles<MyToggle>> = LazyLock::new(|| {
     let mut toggle:EnumToggles<MyToggle> = EnumToggles::new();
     let filepath = env::var("TOGGLES_FILE");
     match filepath {

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -20,11 +20,11 @@ fn enum_toggles(toggles: &EnumToggles<TestToggles>) {
     black_box(toggles.get(TestToggles::Spades as usize));
 }
 
-fn map_toggles(hash_map_toggles: &HashMap<&'static str, bool>) {
-    black_box(hash_map_toggles.get("Hearts"));
-    black_box(hash_map_toggles.get("Tiles"));
-    black_box(hash_map_toggles.get("Pikes"));
-    black_box(hash_map_toggles.get("Spades"));
+fn list_toggles(list_toggles_value: &Vec<bool>) {
+    black_box(list_toggles_value[TestToggles::Hearts as usize]);
+    black_box(list_toggles_value[TestToggles::Tiles as usize]);
+    black_box(list_toggles_value[TestToggles::Pikes as usize]);
+    black_box(list_toggles_value[TestToggles::Spades as usize]);
 }
 
 fn compare_methods(c: &mut Criterion) {
@@ -38,6 +38,8 @@ fn compare_methods(c: &mut Criterion) {
     hash_map_toggles.insert("Pikes", false);
     hash_map_toggles.insert("Spades", false);
 
+    let list_toggles_value: Vec<bool> = vec![false; 4];
+
     group.bench_with_input(
         BenchmarkId::new("Readonly-toggles", "enum_toggles"),
         &toggles,
@@ -45,9 +47,9 @@ fn compare_methods(c: &mut Criterion) {
     );
 
     group.bench_with_input(
-        BenchmarkId::new("Readonly-toggles", "HashMap"),
-        &hash_map_toggles,
-        |b, input| b.iter(|| map_toggles(black_box(input))),
+        BenchmarkId::new("Readonly-toggles", "List"),
+        &list_toggles_value,
+        |b, input| b.iter(|| list_toggles(black_box(input))),
     );
 
     group.finish();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,9 @@
 //! ```rust
 //! use enum_toggles::EnumToggles;
 //! use log::warn;
-//! use once_cell::sync::Lazy;
 //! use std::env;
 //! use std::ops::Deref;
+//! use std::sync::LazyLock;
 //! use strum_macros::{AsRefStr, EnumIter};
 //!
 //! #[derive(AsRefStr, EnumIter, PartialEq)]
@@ -43,7 +43,7 @@
 //!     FeatureB,
 //! }
 //!
-//! pub static TOGGLES: Lazy<EnumToggles<MyToggle>> = Lazy::new(|| {
+//! pub static TOGGLES: LazyLock<EnumToggles<MyToggle>> = LazyLock::new(|| {
 //!     let mut toggle:EnumToggles<MyToggle> = EnumToggles::new();
 //!     let filepath = env::var("TOGGLES_FILE");
 //!     match filepath {
@@ -198,13 +198,13 @@ mod tests {
     }
 
     #[test]
-    fn default() {
+    fn test_default() {
         let toggles: EnumToggles<TestToggles> = EnumToggles::default();
         assert_eq!(toggles.toggles_value.len(), TestToggles::iter().count());
     }
 
     #[test]
-    fn set_all() {
+    fn test_set_all() {
         let mut toggles: EnumToggles<TestToggles> = EnumToggles::new();
         toggles.set_all(HashMap::from([("Toggle1".to_string(), true)]));
         assert_eq!(toggles.get(TestToggles::Toggle1 as usize), true);
@@ -212,7 +212,7 @@ mod tests {
     }
 
     #[test]
-    fn set_by_name() {
+    fn test_set_by_name() {
         let mut toggles: EnumToggles<TestToggles> = EnumToggles::new();
         assert_eq!(toggles.get(TestToggles::Toggle1 as usize), false);
         toggles.set_by_name("Toggle1", true);
@@ -222,13 +222,13 @@ mod tests {
     }
 
     #[test]
-    fn display() {
+    fn test_display() {
         let toggles: EnumToggles<TestToggles> = EnumToggles::new();
         assert_eq!(format!("{:?}", toggles).is_empty(), false);
     }
 
     #[test]
-    fn load_from_file() {
+    fn test_load_from_file() {
         // Create a temporary file
         let mut temp_file =
             tempfile::NamedTempFile::new().expect("Unable to create temporary file");
@@ -261,7 +261,7 @@ mod tests {
     #[should_panic(
         expected = "Out-of-bounds access. The provided toggle_id is 5, but the array size is 2. Please use the default enum value."
     )]
-    fn deviant_toggles() {
+    fn test_deviant_toggles() {
         let mut toggles: EnumToggles<DeviantToggles> = EnumToggles::new();
         toggles.set(DeviantToggles::Toggle1 as usize, true);
     }


### PR DESCRIPTION
- Improve the standardization of the syntax for the tests 
- Replace Lazy by LazyLock
- Improve the benchmark with a relevant comparison